### PR TITLE
485方向切换，作为主机时，波特率115200，

### DIFF
--- a/Device/SerialPort.cpp
+++ b/Device/SerialPort.cpp
@@ -304,9 +304,22 @@ void SerialPort::Set485(bool flag)
 {
 	if (RS485)
 	{
-		if (!flag) Sys.Sleep(1);
+		if (!flag)
+		{
+			//切换到接收需要等待发送完成
+			//需要根据实际测试值修改
+			switch (this->_baudRate)
+			{
+			case 115200:
+				Sys.Delay(100);
+				break;
+			default:
+				Sys.Sleep(1);
+				break;
+			}			
+		}
 		*RS485 = flag;
-		if (flag) Sys.Sleep(1);
+		/*if (flag) Sys.Sleep(1);*/
 		/*if(flag)
 			debug_printf("485 高\r\n");
 		else


### PR DESCRIPTION
发送后延时导致从机的前几个字节接收不到，延时从1ms调整为0.1ms。
切换到接收模式不需要延时。